### PR TITLE
Automatically removes the Tumblr notification urging users to uninstall Missing-E

### DIFF
--- a/chrome/background.html
+++ b/chrome/background.html
@@ -1107,6 +1107,7 @@ chrome.extension.onRequest.addListener(function(request, sender, sendResponse) {
             settings.replaceIcons = getSetting("MissingE_dashboardTweaks_replaceIcons",1);
             settings.postLinks = getSetting("MissingE_dashboardTweaks_postLinks",1);
             settings.reblogReplies = getSetting("MissingE_dashboardTweaks_reblogReplies",0);
+            settings.disableAlert = getSetting("MissingE_dashboardTweaks_disableAlert",0);
             settings.widescreen = getSetting("MissingE_dashboardTweaks_widescreen",0);
             settings.queueArrows = getSetting("MissingE_dashboardTweaks_queueArrows",1);
             settings.expandAll = getSetting("MissingE_dashboardTweaks_expandAll",1);

--- a/core/dashboardTweaks/dashboardTweaks.js
+++ b/core/dashboardTweaks/dashboardTweaks.js
@@ -388,6 +388,16 @@ MissingE.packages.dashboardTweaks = {
    run: function() {
       var settings = this.settings
       var lang = $('html').attr('lang');
+	  
+      if (settings.experimental === 1 &&
+          settings.disableAlert === 1 &&
+          document.body.id === "dashboard_index") {
+			if($("#detection_alert").length) { //Popup exists
+				$("#overlay").hide();
+				$("#detection_alert").hide();
+				$('body').css("overflow","visible");
+			}
+	  }
 
       if (extension.isSafari) {
          extension.insertStyleSheet("core/dashboardTweaks/replaceIcons.css");

--- a/core/options.html
+++ b/core/options.html
@@ -168,6 +168,7 @@ function loadScripts() {
 <tr><td colspan="2" class="odd">Add <em>Shuffle</em> button to the Queue</td><td class="odd"><input type="checkbox" name="MissingE_dashboardTweaks_randomQueue" value="0" checked="checked" class="simple_setting" /></td></tr>
 <tr><td colspan="2" class="even">Enable sorting of notes in dashboard posts</td><td class="even"><input type="checkbox" name="MissingE_dashboardTweaks_sortableNotes" value="0" checked="checked" class="simple_setting" /></td></tr>
 <tr><td colspan="2" class="odd experimental"><strong>[EXPERIMENTAL]</strong> Allow replies to reblogs<br /><small><em><a href="http://missinge.infraware.ca/faq#experimental-reblogReplies">About this experimental feature</a></em></small></td><td class="odd experimental"><input type="checkbox" name="MissingE_dashboardTweaks_reblogReplies" value="0" class="simple_setting" /></td></tr>
+<tr><td colspan="2" class="even experimental"><strong>[EXPERIMENTAL]</strong> Disable "Uninstall Missing-E" Alert<br /><small><em>Removes the official Tumblr warning against Missing-E.</em></small></td><td class="even experimental"><input type="checkbox" name="MissingE_dashboardTweaks_disableAlert" value="0" class="simple_setting" /></td></tr>
 </table>
 </form>
 </div>

--- a/core/options.js
+++ b/core/options.js
@@ -20,7 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with 'Missing e'. If not, see <http://www.gnu.org/licenses/>.
  */
-
 (function($) {
 
 MissingE.utilities.options = {
@@ -297,6 +296,7 @@ MissingE.utilities.options = {
             MissingE.utilities.options.loadCheck(frm,'MissingE_dashboardTweaks_replaceIcons',1);
             MissingE.utilities.options.loadCheck(frm,'MissingE_dashboardTweaks_postLinks',1);
             MissingE.utilities.options.loadCheck(frm,'MissingE_dashboardTweaks_reblogReplies',0);
+            MissingE.utilities.options.loadCheck(frm,'MissingE_dashboardTweaks_disableAlert',0);
             MissingE.utilities.options.loadCheck(frm,'MissingE_dashboardTweaks_widescreen',0);
             MissingE.utilities.options.loadCheck(frm,'MissingE_dashboardTweaks_queueArrows',1);
             MissingE.utilities.options.loadCheck(frm,'MissingE_dashboardTweaks_expandAll',1);

--- a/firefox/missinge/lib/main.js
+++ b/firefox/missinge/lib/main.js
@@ -161,6 +161,7 @@ function getAllSettings(getStale) {
    settings.MissingE_dashboardTweaks_replaceIcons = getSetting("extensions.MissingE.dashboardTweaks.replaceIcons",1);
    settings.MissingE_dashboardTweaks_postLinks = getSetting("extensions.MissingE.dashboardTweaks.postLinks",1);
    settings.MissingE_dashboardTweaks_reblogReplies = getSetting("extensions.MissingE.dashboardTweaks.reblogReplies",0);
+   settings.MissingE_dashboardTweaks_disableAlert = getSetting("extensions.MissingE.dashboardTweaks.disableAlert",0);
    settings.MissingE_dashboardTweaks_widescreen = getSetting("extensions.MissingE.dashboardTweaks.widescreen",0);
    settings.MissingE_dashboardTweaks_queueArrows = getSetting("extensions.MissingE.dashboardTweaks.queueArrows",1);
    settings.MissingE_dashboardTweaks_expandAll = getSetting("extensions.MissingE.dashboardTweaks.expandAll",1);
@@ -1304,6 +1305,7 @@ function handleMessage(message, myWorker) {
             settings.replaceIcons = getSetting("extensions.MissingE.dashboardTweaks.replaceIcons",1);
             settings.postLinks = getSetting("extensions.MissingE.dashboardTweaks.postLinks",1);
             settings.reblogReplies = getSetting("extensions.MissingE.dashboardTweaks.reblogReplies",0);
+            settings.disableAlert = getSetting("extensions.MissingE.dashboardTweaks.disableAlert",0);
             settings.widescreen = getSetting("extensions.MissingE.dashboardTweaks.widescreen",0);
             settings.queueArrows = getSetting("extensions.MissingE.dashboardTweaks.queueArrows",1);
             settings.expandAll = getSetting("extensions.MissingE.dashboardTweaks.expandAll",1);


### PR DESCRIPTION
This commit adds an experimental option to remove the notification. This option defaults to off. It is experimental because I'm not exactly sure what tumblr is doing server-side with this information, this option just removes the client side effects. What I _do_ know is that the notification is added in server side, and uses a cookie to track the response, but that seems rather irrelevant.

You may be apprehensive about antagonizing tumblr by adding this feature, but my reasoning is that Missing-E is an extension built for the sole purpose of improving the user experience and usability of tumblr. The notification does not stop showing up when you click "Acknowledge" or "Uninstall", and therefore detracts from both usability and the user experience, and thus I feel it is reasonable to add a feature that removes such a notification. Remember - It is opt-in, and hidden under the experimental tag. Only people who know about it and _really_ want it will use it!

That said, if you don't want to include it, I perfectly understand. Thanks for the hard work, I much appreciate the extension. :)
