### PR TITLE
Add blockNotes option to Missing-E

### DIFF
--- a/chrome/background.html
+++ b/chrome/background.html
@@ -1120,6 +1120,9 @@ chrome.extension.onRequest.addListener(function(request, sender, sendResponse) {
             settings.reblogLinks = getSetting("MissingE_dashLinksToTabs_reblogLinks",0);
             settings.editLinks = getSetting("MissingE_dashLinksToTabs_editLinks",0);
             break;
+		 case "blockNotes":
+			settings.blocked = getSetting("MissingE_blockNotes_blocked",'{}');
+			break;
          case "replyReplies":
             settings.showAvatars = getSetting("MissingE_replyReplies_showAvatars",1);
             settings.smallAvatars = getSetting("MissingE_replyReplies_smallAvatars",1);
@@ -1541,6 +1544,20 @@ chrome.extension.onRequest.addListener(function(request, sender, sendResponse) {
          else
             activeScripts.timestamps = false;
       }
+      if (sender.tab.url == request.url &&
+          MissingE.isTumblrURL(sender.tab.url,
+                      ["dashboard",
+                       "blog",
+                       "likes",
+                       "tagged",
+                       "messages"])) {
+         if (getSetting("MissingE_blockNotes_enabled",1) == 1) {
+            activeScripts.blockNotes = true;
+            chrome.tabs.executeScript(sender.tab.id, {file: "core/blockNotes/blockNotes.js"});
+         }
+         else
+            activeScripts.blockNotes = false;
+	  }
       if (sender.tab.url == request.url &&
           MissingE.isTumblrURL(sender.tab.url,
                       ["dashboard",

--- a/core/blockNotes/blockNotes.js
+++ b/core/blockNotes/blockNotes.js
@@ -1,0 +1,158 @@
+/*
+ * 'Missing e' Extension
+ *
+ * Copyright 2011, Jeremy Cutler
+ * Released under the GPL version 3 licence.
+ * SEE: license/GPL-LICENSE.txt
+ *
+ * This file is part of 'Missing e'.
+ *
+ * 'Missing e' is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * 'Missing e' is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with 'Missing e'. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*global extension, jQuery, MissingE */
+
+(function($){
+
+MissingE.packages.blockNotes = {
+   hideNotification: function(item) {
+		var i = $(item);
+		if(i.hasClass('first_notification')) {
+			var e = i.next('.notification');
+			if(e.hasClass('last_notification')) {
+				e.removeClass('last_notification');
+				e.addClass('single_notification');
+			} else {
+				e.addClass('first_notification');
+			}
+		}
+		if(i.hasClass('last_notification')) {
+			var e = i.prev('.notification');
+			if(e.hasClass('first_notification')) {
+				e.removeClass('first_notification');
+				e.addClass('single_notification');
+			} else {
+				e.addClass('last_notification');
+			}		
+		}
+		
+		i.hide();
+   },
+
+   loadNotification: function(item) {
+      var lang = $('html').attr('lang');
+
+	  //Only operate on notifications
+      if (item.tagName === "LI" && $(item).hasClass("notification")) {
+		var index;
+		var links = $(item).find('a');
+		//Ensure it is a "like" notification
+		links.each(function(i,e) {
+			if($(e).html() == 'post') { //Kind of hackish
+				index = i;
+				return false;
+			}
+		});
+		if(index == undefined)
+			return false;
+			
+		$(item).find('.block').html('block user'); //Make more explicit
+		
+		//Find post ID from link url
+		var url = links.get(index).href;
+		var postId = url.split('/')[4];
+		
+		//Add postId to notification
+		$(item).addClass('MissingE_blockNotes_'+postId);
+		
+		//Build "block notes" link
+		var newlink = $('<a></a>').addClass('block')
+			.addClass('MissingE_blockNotes')
+			.attr('MissingE_blockNotes_id',postId)
+			.attr('MissingE_blockNotes_link',url)
+			.attr('MissingE_blockNotes_text',links.get(index+1).innerHTML)
+			.html('block notes');
+		
+		$(item).append(newlink);
+		
+		if(MissingE.packages.blockNotes.settings['blocked'].hasOwnProperty(postId)) //If already blocked
+			MissingE.packages.blockNotes.hideNotification(item);
+      }
+   },
+   
+   updateBlocked: function() {
+      if (extension.isFirefox ||
+          extension.isSafari) {
+         extension.sendRequest("change-setting", {name: 'MissingE_blockNotes_blocked', val: JSON.stringify(MissingE.packages.blockNotes.settings['blocked'])});
+      }
+      else {
+         extension.backupVal('MissingE_blockNotes_blocked', JSON.stringify(MissingE.packages.blockNotes.settings['blocked']) );
+      }
+   },
+
+   run: function() {
+      $('#posts li.notification').each(function(){
+         MissingE.packages.blockNotes.loadNotification(this);
+      });
+	  
+      extension.addAjaxListener(function(type,list) {
+         if (type === 'notes') { return; }
+         $.each(list, function(i,val) {
+            MissingE.packages.blockNotes.loadNotification($('#'+val).get(0));
+         });
+      });
+	  
+	  $('body').delegate('.MissingE_blockNotes','click',function(event) {
+		MissingE.packages.blockNotes.settings['blocked'][$(this).attr('MissingE_blockNotes_id')] = {'text': $(this).attr('MissingE_blockNotes_text'), 'link': $(this).attr('MissingE_blockNotes_link') };
+		$('.MissingE_blockNotes_' + $(this).attr('MissingE_blockNotes_id')).each(function(i,e) { MissingE.packages.blockNotes.hideNotification(e); });
+		MissingE.packages.blockNotes.updateBlocked();
+	  });
+   },
+
+   init: function() {
+      $('head').append('<style type="text/css"> \
+		.MissingE_blockNotes { \
+			right: 78px !important; \
+		} \
+		#posts .notification .hide_overflow { \
+			max-width: 400px !important; \
+		} \
+		</style>');
+      extension.sendRequest("settings", {component: "blockNotes"},
+                            function(response) {
+         if (response.component === "blockNotes") {
+            var i;
+            MissingE.packages.blockNotes.settings = {};
+            for (i in response) {
+               if (response.hasOwnProperty(i) &&
+                   i !== "component") {
+				   if(i === 'blocked') {
+					MissingE.packages.blockNotes.settings[i] = JSON.parse(response[i]);
+				   } else {
+					MissingE.packages.blockNotes.settings[i] = response[i];
+				   }
+               }
+            }
+            MissingE.packages.blockNotes.run();
+         }
+      });
+   }
+};
+
+if (extension.isChrome ||
+    extension.isFirefox) {
+   MissingE.packages.blockNotes.init();
+}
+
+}(jQuery));

--- a/core/options.html
+++ b/core/options.html
@@ -325,6 +325,22 @@ function loadScripts() {
 <span class="arrow"></span>
 </div>
 </li>
+<li id="blockNotes_section" class="post not_mine regular">
+<div class="post_content">
+<form id="blockNotes_options">
+<div class="post_title"><input class="toggler" type="checkbox" name="active" checked="checked" value="1" /> Block Notes</div>
+<p>Allows you to block notes for specific posts. Useful if your dashboard is being flooded after your post goes viral.</p>
+<p>Blocked Notes:</p>
+<table class="options_table">
+</table>
+</form>
+</div>
+<div class="clear"></div>
+<div>
+<div class="post_avatar" style="background-image:url('icons/timestamps_avatar.png');"></div>
+<span class="arrow"></span>
+</div>
+</li>
 </div>
 <div id="posting_posts">
 <li id="massEditor" class="post not_mine regular">

--- a/core/options.js
+++ b/core/options.js
@@ -200,6 +200,7 @@ MissingE.utilities.options = {
                         "dashLinksToTabs",
                         "safeDash",
                         "timestamps",
+                        "blockNotes",
                         "magnifier",
                         "betterReblogs",
                         "gotoDashPost",
@@ -250,6 +251,31 @@ MissingE.utilities.options = {
             MissingE.utilities.options.loadCheck(frm,'MissingE_sidebarTweaks_followingLink',0);
             frm.MissingE_sidebarTweaks_retries.value = MissingE.utilities.options.getStorage('MissingE_sidebarTweaks_retries',MissingE.defaultRetries);
          }
+         else if (v == "blockNotes") {
+			var blocked = JSON.parse(MissingE.utilities.options.getStorage('MissingE_blockNotes_blocked','{}'));
+			var even = 0;
+			for( var key in blocked ) {
+				if( blocked.hasOwnProperty(key) ) {
+					$('#blockNotes_options .options_table').append(
+						$('<tr></tr>')
+							.attr('id','blockNotes_row_'+key)
+							.addClass((even ? 'even' : 'odd'))
+							.html('<td colspan="2" class="desc"><a href="' + blocked[key]['link'] + '">' + blocked[key]['text'] + '</a></td><td><a href="#" class="blockNotes_unblock" id="blockNotes_unblock_' + key + '">Unblock</td>')
+						);
+					even = (even + 1) % 2;
+				}
+			}
+			$('body').delegate(".blockNotes_unblock","click",function(event) {
+				var fields = $(this).attr("id").split("_");
+				var key = fields[fields.length - 1];
+				$('#blockNotes_row_'+key).hide();
+				var blocked = JSON.parse(MissingE.utilities.options.getStorage('MissingE_blockNotes_blocked','{}'));
+				if( blocked.hasOwnProperty(key) ) {
+					delete blocked[key];
+					MissingE.utilities.options.setStorage('MissingE_blockNotes_blocked',JSON.stringify(blocked));
+				}
+			});
+		 }
          else if (v == "dashLinksToTabs") {
             MissingE.utilities.options.loadCheck(frm,'MissingE_dashLinksToTabs_newPostTabs',1);
             MissingE.utilities.options.loadCheck(frm,'MissingE_dashLinksToTabs_sidebar',0);

--- a/firefox/missinge/lib/main.js
+++ b/firefox/missinge/lib/main.js
@@ -129,6 +129,7 @@ var componentList = ["dashboardTweaks",
                      "dashLinksToTabs",
                      "safeDash",
                      "timestamps",
+                     "blockNotes",
                      "magnifier",
                      "betterReblogs",
                      "gotoDashPost",
@@ -180,6 +181,7 @@ function getAllSettings(getStale) {
    settings.MissingE_dashLinksToTabs_editLinks = getSetting("extensions.MissingE.dashLinksToTabs.editLinks",0);
    settings.MissingE_timestamps_retries = getSetting("extensions.MissingE.timestamps.retries",MissingE.defaultRetries);
    settings.MissingE_timestamps_format = getSetting("extensions.MissingE.timestamps.format",MissingE.defaultFormat);
+   settings.MissingE_blockNotes_blocked = getSetting("extensions.MissingE.blockNotes.blocked",'{}');
    settings.MissingE_postingTweaks_photoReplies = getSetting("extensions.MissingE.postingTweaks.photoReplies",1);
    settings.MissingE_postingTweaks_addUploader = getSetting("extensions.MissingE.postingTweaks.addUploader",1);
    settings.MissingE_postingTweaks_quickButtons = getSetting("extensions.MissingE.postingTweaks.quickButtons",1);
@@ -1332,6 +1334,9 @@ function handleMessage(message, myWorker) {
                settings.defaultTags = settings.defaultTags.replace(/, /g,',').split(',');
             }
             break;
+		case "blockNotes":
+			settings.blocked = getSetting("extensions.MissingE.blockNotes.blocked",'{}');
+			break;
          case "postCrushes_fill":
          case "postCrushes":
             settings.prefix = getSetting("extensions.MissingE.postCrushes.prefix","Tumblr Crushes:");
@@ -1610,6 +1615,20 @@ function handleMessage(message, myWorker) {
          }
          else
             activeScripts.postingTweaks = false;
+      }
+      if (!message.isFrame &&
+          MissingE.isTumblrURL(message.url,
+                               ["dashboard",
+                                "blog",
+                                "likes",
+                                "tagged",
+                                "messages"])) {
+         if (getSetting("extensions.MissingE.blockNotes.enabled",1) == 1) {
+            injectScripts.push(data.url("core/blockNotes/blockNotes.js"));
+            activeScripts.blockNotes = true;
+         }
+         else
+            activeScripts.blockNotes = false;
       }
       if (!message.isFrame &&
           MissingE.isTumblrURL(message.url, ["reblog"])) {

--- a/missinge.safariextension/Info.plist
+++ b/missinge.safariextension/Info.plist
@@ -78,6 +78,7 @@
 				<string>core/replyReplies/replyReplies_fill.js</string>
 				<string>core/safeDash/safeDash.js</string>
 				<string>core/timestamps/timestamps.js</string>
+				<string>core/blockNotes/blockNotes.js</string>
 				<string>core/massEditor/massEditor.js</string>
 				<string>core/postingTweaks/postingTweaks_post.js</string>
 				<string>core/common/zindexFix.js</string>

--- a/missinge.safariextension/Settings.plist
+++ b/missinge.safariextension/Settings.plist
@@ -134,6 +134,16 @@
 		<key>DefaultValue</key>
 		<real>1</real>
 		<key>Key</key>
+		<string>MissingE_blockNotes_enabled</string>
+		<key>Title</key>
+		<string></string>
+		<key>Type</key>
+		<string>Hidden</string>
+	</dict>
+	<dict>
+		<key>DefaultValue</key>
+		<real>1</real>
+		<key>Key</key>
 		<string>MissingE_magnifier_enabled</string>
 		<key>Title</key>
 		<string></string>
@@ -545,6 +555,16 @@
 		<string>%Y-%m-%D %H:%i</string>
 		<key>Key</key>
 		<string>MissingE_timestamps_format</string>
+		<key>Title</key>
+		<string></string>
+		<key>Type</key>
+		<string>Hidden</string>
+	</dict>
+	<dict>
+		<key>DefaultValue</key>
+		<string>{}</string>
+		<key>Key</key>
+		<string>MissingE_blockNotes_blocked</string>
 		<key>Title</key>
 		<string></string>
 		<key>Type</key>

--- a/missinge.safariextension/Settings.plist.template
+++ b/missinge.safariextension/Settings.plist.template
@@ -134,6 +134,16 @@
 		<key>DefaultValue</key>
 		<real>1</real>
 		<key>Key</key>
+		<string>MissingE_blockNotess_enabled</string>
+		<key>Title</key>
+		<string></string>
+		<key>Type</key>
+		<string>Hidden</string>
+	</dict>
+	<dict>
+		<key>DefaultValue</key>
+		<real>1</real>
+		<key>Key</key>
 		<string>MissingE_magnifier_enabled</string>
 		<key>Title</key>
 		<string></string>
@@ -545,6 +555,16 @@
 		<string>%Y-%m-%D %H:%i</string>
 		<key>Key</key>
 		<string>MissingE_timestamps_format</string>
+		<key>Title</key>
+		<string></string>
+		<key>Type</key>
+		<string>Hidden</string>
+	</dict>
+	<dict>
+		<key>DefaultValue</key>
+		<string>{}</string>
+		<key>Key</key>
+		<string>MissingE_blockNotes_blocked</string>
 		<key>Title</key>
 		<string></string>
 		<key>Type</key>

--- a/missinge.safariextension/global.html
+++ b/missinge.safariextension/global.html
@@ -34,6 +34,7 @@ var componentList = ["dashboardTweaks",
                      "dashLinksToTabs",
                      "safeDash",
                      "timestamps",
+                     "blockNotes",
                      "magnifier",
                      "betterReblogs",
                      "gotoDashPost",
@@ -1175,6 +1176,7 @@ function handleRequest(request) {
       settings.MissingE_dashLinksToTabs_editLinks = getSetting("MissingE_dashLinksToTabs_editLinks",0);
       settings.MissingE_timestamps_retries = getSetting("MissingE_timestamps_retries",MissingE.defaultRetries);
       settings.MissingE_timestamps_format = getSetting("MissingE_timestamps_format",MissingE.defaultFormat);
+      settings.MissingE_blockNotes_blocked = getSetting("MissingE_timestamps_format",'{}');
       settings.MissingE_postingTweaks_photoReplies = getSetting("MissingE_postingTweaks_photoReplies",1);
       settings.MissingE_postingTweaks_addUploader = getSetting("MissingE_postingTweaks_addUploader",1);
       settings.MissingE_postingTweaks_quickButtons = getSetting("MissingE_postingTweaks_quickButtons",1);
@@ -1259,6 +1261,9 @@ function handleRequest(request) {
             settings.randomQueue = getSetting("MissingE_dashboardTweaks_randomQueue",0);
             settings.sortableNotes = getSetting("MissingE_dashboardTweaks_sortableNotes",1);
             break;
+		 case "blockNotes":
+			settings.blocked = getSetting("MissingE_blockNotes_blocked",'{}');
+			break;
          case "dashLinksToTabs":
             settings.newPostTabs = getSetting("MissingE_dashLinksToTabs_newPostTabs",1);
             settings.sidebar = getSetting("MissingE_dashLinksToTabs_sidebar",0);
@@ -1561,6 +1566,19 @@ function handleRequest(request) {
          }
          else
             activeScripts.timestamps = false;
+      }
+      if (!request.message.isFrame &&
+          MissingE.isTumblrURL(request.message.url,
+                      ["dashboard",
+                       "blog",
+                       "likes",
+                       "tagged",
+                       "messages"])) {
+         if (getSetting("MissingE_blockNotes_enabled",1) == 1) {
+            activeScripts.blockNotes = true;
+         }
+         else
+            activeScripts.blockNotes = false;
       }
       if (!request.message.isFrame &&
           MissingE.isTumblrURL(request.message.url,


### PR DESCRIPTION
Allows users to block Like or Reblog notifications on their dashboard on a post by post basis. Has not been tested on Safari as I couldn't figure out how to build the extension without the dev key. Also doesn't have a proper icon for the options page.
